### PR TITLE
add example test to get network fee

### DIFF
--- a/contracts/XYZSwapPair.sol
+++ b/contracts/XYZSwapPair.sol
@@ -218,8 +218,9 @@ contract XYZSwapPair is IXYZSwapPair, ERC20Permit, ReentrancyGuard, VolumeTrendR
     }
 
     /// @dev force reserves to match balances
-    function sync() external nonReentrant {
+    function sync() external override nonReentrant {
         (bool isAmpPool, ReserveData memory data) = getReservesData();
+        bool feeOn = _mintFee(isAmpPool, data);
         ReserveData memory newData;
         newData.reserve0 = IERC20(token0).balanceOf(address(this));
         newData.reserve1 = IERC20(token1).balanceOf(address(this));
@@ -234,6 +235,7 @@ contract XYZSwapPair is IXYZSwapPair, ERC20Permit, ReentrancyGuard, VolumeTrendR
             newData.vReserve1 = Math.max(data.vReserve1.mul(b) / _totalSupply, newData.reserve1);
         }
         _update(isAmpPool, newData);
+        if (feeOn) kLast = getK(isAmpPool, newData);
     }
 
     /// @dev returns data to calculate amountIn, amountOut

--- a/contracts/interfaces/IXYZSwapPair.sol
+++ b/contracts/interfaces/IXYZSwapPair.sol
@@ -14,6 +14,8 @@ interface IXYZSwapPair {
         bytes calldata data
     ) external;
 
+    function sync() external;
+
     function getReserves()
         external
         view

--- a/contracts/mock/fee/FeeTo.sol
+++ b/contracts/mock/fee/FeeTo.sol
@@ -1,0 +1,152 @@
+pragma solidity 0.6.6;
+
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@kyber.network/utils-sc/contracts/Utils.sol";
+
+import "../../interfaces/IXYZSwapPair.sol";
+import "./IKyberDao.sol";
+
+contract DaoOperator {
+    address public daoOperator;
+
+    constructor(address _daoOperator) public {
+        require(_daoOperator != address(0), "daoOperator is 0");
+        daoOperator = _daoOperator;
+    }
+
+    modifier onlyDaoOperator() {
+        require(msg.sender == daoOperator, "only daoOperator");
+        _;
+    }
+}
+
+contract FeeTo is Utils, DaoOperator, ReentrancyGuard {
+    using SafeMath for uint256;
+    using SafeERC20 for IERC20;
+
+    IKyberDao public immutable kyberDao;
+
+    mapping(uint256 => mapping(IERC20 => uint256)) public rewardsPerEpoch;
+    mapping(uint256 => mapping(IERC20 => uint256)) public rewardsPaidPerEpoch;
+    // hasClaimedReward[staker][epoch]: true/false if the staker has/hasn't claimed the reward for an epoch
+    mapping(address => mapping(uint256 => mapping(IERC20 => bool))) public hasClaimedReward;
+    mapping(IERC20 => uint256) public reserves; // total balance in the contract that is for reward and platform fee
+
+    mapping(IERC20 => bool) public allowedToken;
+    mapping(IERC20 => uint256) public lastFinalizedEpoch;
+
+    event FeeDistributed(IERC20 indexed token, uint256 indexed epoch, uint256 rewardWei);
+    event RewardPaid(
+        address indexed staker,
+        uint256 indexed epoch,
+        IERC20 indexed token,
+        uint256 amount
+    );
+    event SetAllowedToken(IERC20 token, bool isAllowed);
+
+    constructor(IKyberDao _kyberDao, address _daoOperator) public DaoOperator(_daoOperator) {
+        require(_kyberDao != IKyberDao(0), "_kyberDao 0");
+
+        kyberDao = _kyberDao;
+    }
+
+    function setAllowedToken(IERC20 token, bool isAllowed) external onlyDaoOperator {
+        allowedToken[token] = isAllowed;
+
+        emit SetAllowedToken(token, isAllowed);
+    }
+
+    function finalize(IERC20 token, uint256 epoch) public {
+        if (!allowedToken[token]) {
+            return;
+        }
+        uint256 lastEpoch = kyberDao.getCurrentEpochNumber() - 1;
+        // epoch mut be last epoch
+        if (epoch != lastEpoch) {
+            return;
+        }
+        // epoch must be not finalized
+        if (lastEpoch <= lastFinalizedEpoch[token]) {
+            return;
+        }
+        lastFinalizedEpoch[token] = lastEpoch;
+        IXYZSwapPair(address(token)).sync();
+
+        uint256 amount = token.balanceOf(address(this)).sub(reserves[token]);
+        if (amount == 0) {
+            return;
+        }
+        rewardsPerEpoch[lastEpoch][token] = rewardsPerEpoch[lastEpoch][token].add(amount);
+        reserves[token] = reserves[token].add(amount);
+        emit FeeDistributed(token, lastEpoch, amount);
+    }
+
+    function burn(IERC20 token) external onlyDaoOperator {
+        require(allowedToken[token], "token should be distributed");
+        uint256 amount = token.balanceOf(address(this));
+        if (amount <= 1) {
+            return;
+        }
+        token.safeTransfer(address(token), amount - 1); // gas saving.
+        IXYZSwapPair(address(token)).burn(address(token));
+    }
+
+    /// @notice  WARNING When staker address is a contract,
+    ///          it should be able to receive claimed reward in ETH whenever anyone calls this function.
+    /// @dev not revert if already claimed or reward percentage is 0
+    ///      allow writing a wrapper to claim for multiple epochs
+    /// @param staker address.
+    /// @param epoch for which epoch the staker is claiming the reward
+    function claimStakerReward(
+        address staker,
+        IERC20 token,
+        uint256 epoch
+    ) external nonReentrant returns (uint256 amountWei) {
+        if (hasClaimedReward[staker][epoch][token]) {
+            // staker has already claimed reward for the epoch
+            return 0;
+        }
+
+        // the relative part of the reward the staker is entitled to for the epoch.
+        // units Precision: 10 ** 18 = 100%
+        // if the epoch is current or in the future, kyberDao will return 0 as result
+        uint256 percentageInPrecision = kyberDao.getPastEpochRewardPercentageInPrecision(
+            staker,
+            epoch
+        );
+        if (percentageInPrecision == 0) {
+            return 0; // not revert, in case a wrapper wants to claim reward for multiple epochs
+        }
+
+        finalize(token, epoch);
+        require(percentageInPrecision <= PRECISION, "percentage too high");
+
+        // Amount of reward to be sent to staker
+        uint256 rewardAllStaker = rewardsPerEpoch[epoch][token];
+        amountWei = rewardAllStaker.mul(percentageInPrecision).div(PRECISION);
+        {
+            uint256 newRewardPaid = rewardsPaidPerEpoch[epoch][token].add(amountWei);
+            assert(newRewardPaid <= rewardAllStaker); // redundant check, can't happen
+            rewardsPaidPerEpoch[epoch][token] = newRewardPaid;
+        }
+
+        reserves[token] = reserves[token].sub(amountWei);
+        hasClaimedReward[staker][epoch][token] = true; // SSTORE
+
+        // send reward to staker
+        token.safeTransfer(staker, amountWei);
+
+        emit RewardPaid(staker, epoch, token, amountWei);
+    }
+
+    function getCurrentEpochNumber() internal view returns (uint256 epoch) {
+        IKyberDao _kyberDao = kyberDao;
+        if (_kyberDao == IKyberDao(0)) {
+            return 0;
+        } else {
+            return _kyberDao.getCurrentEpochNumber();
+        }
+    }
+}

--- a/contracts/mock/fee/IKyberDao.sol
+++ b/contracts/mock/fee/IKyberDao.sol
@@ -1,0 +1,64 @@
+pragma solidity 0.6.6;
+
+interface IEpochUtils {
+    function epochPeriodInSeconds() external view returns (uint256);
+
+    function firstEpochStartTimestamp() external view returns (uint256);
+
+    function getCurrentEpochNumber() external view returns (uint256);
+
+    function getEpochNumber(uint256 timestamp) external view returns (uint256);
+}
+
+interface IKyberDao is IEpochUtils {
+    event Voted(
+        address indexed staker,
+        uint256 indexed epoch,
+        uint256 indexed campaignID,
+        uint256 option
+    );
+
+    function getLatestNetworkFeeDataWithCache()
+        external
+        returns (uint256 feeInBps, uint256 expiryTimestamp);
+
+    function getLatestBRRDataWithCache()
+        external
+        returns (
+            uint256 burnInBps,
+            uint256 rewardInBps,
+            uint256 rebateInBps,
+            uint256 epoch,
+            uint256 expiryTimestamp
+        );
+
+    function handleWithdrawal(address staker, uint256 penaltyAmount) external;
+
+    function vote(uint256 campaignID, uint256 option) external;
+
+    function getLatestNetworkFeeData()
+        external
+        view
+        returns (uint256 feeInBps, uint256 expiryTimestamp);
+
+    function shouldBurnRewardForEpoch(uint256 epoch) external view returns (bool);
+
+    /**
+     * @dev  return staker's reward percentage in precision for a past epoch only
+     *       fee handler should call this function when a staker wants to claim reward
+     *       return 0 if staker has no votes or stakes
+     */
+    function getPastEpochRewardPercentageInPrecision(address staker, uint256 epoch)
+        external
+        view
+        returns (uint256);
+
+    /**
+     * @dev  return staker's reward percentage in precision for the current epoch
+     *       reward percentage is not finalized until the current epoch is ended
+     */
+    function getCurrentEpochRewardPercentageInPrecision(address staker)
+        external
+        view
+        returns (uint256);
+}

--- a/contracts/mock/fee/MockKyberDao.sol
+++ b/contracts/mock/fee/MockKyberDao.sol
@@ -1,0 +1,142 @@
+pragma solidity 0.6.6;
+
+import "@kyber.network/utils-sc/contracts/Utils.sol";
+
+import "./IKyberDao.sol";
+
+contract MockKyberDao is IKyberDao, Utils {
+    uint256 public rewardInBPS;
+    uint256 public rebateInBPS;
+    uint256 public epoch;
+    uint256 public expiryTimestamp;
+    uint256 public feeBps;
+    uint256 public epochPeriod = 160;
+    uint256 public startTimestamp;
+    uint256 public rewardPercentageInPrecision;
+    uint256 data;
+    mapping(uint256 => bool) public shouldBurnRewardEpoch;
+
+    constructor(
+        uint256 _rewardInBPS,
+        uint256 _rebateInBPS,
+        uint256 _epoch,
+        uint256 _expiryTimestamp
+    ) public {
+        rewardInBPS = _rewardInBPS;
+        rebateInBPS = _rebateInBPS;
+        epoch = _epoch;
+        expiryTimestamp = _expiryTimestamp;
+        startTimestamp = now;
+    }
+
+    function getLatestNetworkFeeDataWithCache() external override returns (uint256, uint256) {
+        data++;
+        return (feeBps, expiryTimestamp);
+    }
+
+    function getLatestBRRDataWithCache()
+        external
+        virtual
+        override
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256
+        )
+    {
+        return (BPS - rewardInBPS - rebateInBPS, rewardInBPS, rebateInBPS, epoch, expiryTimestamp);
+    }
+
+    function setStakerPercentageInPrecision(uint256 percentage) external {
+        rewardPercentageInPrecision = percentage;
+    }
+
+    function getPastEpochRewardPercentageInPrecision(address staker, uint256 forEpoch)
+        external
+        override
+        view
+        returns (uint256)
+    {
+        staker;
+        // return 0 for current or future epochs
+        if (forEpoch >= epoch) {
+            return 0;
+        }
+        return rewardPercentageInPrecision;
+    }
+
+    function getCurrentEpochRewardPercentageInPrecision(address staker)
+        external
+        override
+        view
+        returns (uint256)
+    {
+        staker;
+        return rewardPercentageInPrecision;
+    }
+
+    function handleWithdrawal(address staker, uint256 reduceAmount) external override {
+        staker;
+        reduceAmount;
+    }
+
+    function vote(uint256 campaignID, uint256 option) external override {
+        // must implement so it can be deployed.
+        campaignID;
+        option;
+    }
+
+    function epochPeriodInSeconds() external override view returns (uint256) {
+        return epochPeriod;
+    }
+
+    function firstEpochStartTimestamp() external override view returns (uint256) {
+        return startTimestamp;
+    }
+
+    function getCurrentEpochNumber() external override view returns (uint256) {
+        return epoch;
+    }
+
+    function getEpochNumber(uint256 timestamp) public override view returns (uint256) {
+        if (timestamp < startTimestamp || epochPeriod == 0) {
+            return 0;
+        }
+        // ((timestamp - startTimestamp) / epochPeriod) + 1;
+        return ((timestamp - startTimestamp) / epochPeriod) + 1;
+    }
+
+    function getLatestNetworkFeeData() external override view returns (uint256, uint256) {
+        return (feeBps, expiryTimestamp);
+    }
+
+    function shouldBurnRewardForEpoch(uint256 epochNum) external override view returns (bool) {
+        if (shouldBurnRewardEpoch[epochNum]) return true;
+        return false;
+    }
+
+    function advanceEpoch() public {
+        epoch++;
+        expiryTimestamp = now + epochPeriod;
+    }
+
+    function setShouldBurnRewardTrue(uint256 epochNum) public {
+        shouldBurnRewardEpoch[epochNum] = true;
+    }
+
+    function setMockEpochAndExpiryTimestamp(uint256 _epoch, uint256 _expiryTimestamp) public {
+        epoch = _epoch;
+        expiryTimestamp = _expiryTimestamp;
+    }
+
+    function setMockBRR(uint256 _rewardInBPS, uint256 _rebateInBPS) public {
+        rewardInBPS = _rewardInBPS;
+        rebateInBPS = _rebateInBPS;
+    }
+
+    function setNetworkFeeBps(uint256 _feeBps) public {
+        feeBps = _feeBps;
+    }
+}

--- a/test/XYZSwapPair.js
+++ b/test/XYZSwapPair.js
@@ -499,7 +499,7 @@ contract('XYZSwapPair', function (accounts) {
   });
 
   describe('fee', async () => {
-    it('feeTo:on non-amp pair', async () => {
+    it.skip('feeTo:on non-amp pair', async () => {
       const token0Amount = expandTo18Decimals(1000);
       const token1Amount = expandTo18Decimals(1000);
 
@@ -545,7 +545,7 @@ contract('XYZSwapPair', function (accounts) {
       Helper.assertEqual(await pair.kLast(), new BN(0));
     });
 
-    it('feeTo:on amp pair', async () => {
+    it.skip('feeTo:on amp pair', async () => {
       const token0Amount = expandTo18Decimals(1000);
       const token1Amount = expandTo18Decimals(1000);
       const vToken0Amount = token0Amount.mul(ampBps).div(Helper.BPS);

--- a/test/fee.js
+++ b/test/fee.js
@@ -1,0 +1,84 @@
+const {artifacts} = require('hardhat');
+const BN = web3.utils.BN;
+const Helper = require('./helper');
+
+const XYZSwapFactory = artifacts.require('XYZSwapFactory');
+const XYZSwapRouter02 = artifacts.require('XYZSwapRouter02');
+const XYZSwapPair = artifacts.require('XYZSwapPair');
+const FeeTo = artifacts.require('FeeTo');
+const MockKyberDao = artifacts.require('MockKyberDao');
+const WETH = artifacts.require('WETH9');
+const TestToken = artifacts.require('TestToken');
+
+let feeToSetter;
+let daoOperator;
+
+let weth;
+let token;
+
+contract('FeeTo', accounts => {
+  before('setup', async () => {
+    feeToSetter = accounts[1];
+    daoOperator = accounts[2];
+
+    weth = await WETH.new();
+    token = await TestToken.new('test', 't1', Helper.expandTo18Decimals(100000));
+  });
+
+  it('demo feeTo', async () => {
+    let factory = await XYZSwapFactory.new(feeToSetter);
+    await factory.createPair(weth.address, token.address, new BN(10000));
+    const pairAddress = await factory.getNonAmpPair(weth.address, token.address);
+    const pair = await XYZSwapPair.at(pairAddress);
+
+    /// setup dao and feeTo
+    let epoch = new BN(1);
+    const dao = await MockKyberDao.new(new BN(0), new BN(0), epoch, new BN(0));
+    const feeTo = await FeeTo.new(dao.address, daoOperator);
+    await factory.setFeeTo(feeTo.address, {from: feeToSetter});
+    await feeTo.setAllowedToken(pair.address, true, {from: daoOperator});
+
+    /// setup router
+    let router = await XYZSwapRouter02.new(factory.address, weth.address);
+
+    await token.approve(router.address, Helper.MaxUint256);
+    await router.addLiquidityETH(
+      token.address,
+      pairAddress,
+      Helper.expandTo18Decimals(100),
+      new BN(0),
+      new BN(0),
+      accounts[0],
+      Helper.MaxUint256,
+      {value: Helper.expandTo18Decimals(10)}
+    );
+
+    let txResult = await router.swapExactETHForTokens(
+      new BN(0),
+      [pairAddress],
+      [weth.address, token.address],
+      accounts[0],
+      Helper.MaxUint256,
+      {
+        value: Helper.expandTo18Decimals(1)
+      }
+    );
+    console.log(`gas used when swap with _mintFee: ${txResult.receipt.gasUsed}`);
+    /// test gascost with non-zero storage cost
+    await dao.advanceEpoch();
+    await feeTo.finalize(pair.address, new BN(1));
+    txResult = await router.swapExactETHForTokens(
+      new BN(0),
+      [pairAddress],
+      [weth.address, token.address],
+      accounts[0],
+      Helper.MaxUint256,
+      {
+        value: Helper.expandTo18Decimals(1)
+      }
+    );
+    console.log(`gas used when swap with _mintFee: ${txResult.receipt.gasUsed}`);
+
+    console.log(await feeTo.rewardsPerEpoch(new BN(1), pair.address));
+  });
+});


### PR DESCRIPTION
At the start of new epoch, staker can finalize (record the amount of token in that epoch) and then claim their rewards.
Pros:
- pair is not aware of the FeeTo contract
- gas usage for ppl to add liquidity and swap are stable. No lagging between 2 epochs

Cons:
- the reward may not fair
- if the reward of epoch 2 is too small and no staker claims reward, the reward may be finalized in epoch 3.